### PR TITLE
Improve error display (specifically for timeouts)

### DIFF
--- a/check.js
+++ b/check.js
@@ -45,7 +45,11 @@ async function check(htmlURL, state, ipv4Only) {
             jsStatus: {},
         };
         if (res.statusCode !== 200) {
-            serverResult.htmlError = `HTTP ${res.statusCode}`;
+            if (typeof res.statusCode == 'number') {
+                serverResult.htmlError = `HTTP ${res.statusCode}`;
+            } else {
+                serverResult.htmlError = res.statusCode;
+            }
         } else {
             const htmlHash = sha2(res.content);
             serverResult.htmlHash = htmlHash;

--- a/net_utils.js
+++ b/net_utils.js
@@ -81,7 +81,7 @@ async function downloadURL(url, serverIP) {
         return await retry(2, () => _runDownload(url, serverIP), err => err.message === 'timeout');
     } catch(e) {
         return {
-            statusCode: `error ${e.code || e.message}`,
+            statusCode: e.code || e.message,
             serverIP: serverIP,
         };
     }


### PR DESCRIPTION
Previously, we added a number of strings before errors. Make it clearer that a timeout happens.
Can be tested with http://firewall.phihag.de/